### PR TITLE
chore: migrate tests to rstest and release 1.0.0 / 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "iptocc"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 dependencies = [
  "clap",
  "criterion",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "iptocc-py"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "iptocc",
  "pyo3",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "iptocc-wasm"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 dependencies = [
  "iptocc",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,10 +256,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"
@@ -273,10 +327,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "iptocc"
@@ -284,7 +354,7 @@ version = "1.0.0-alpha.2"
 dependencies = [
  "clap",
  "criterion",
- "test-case",
+ "rstest",
 ]
 
 [[package]]
@@ -385,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +493,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -544,6 +629,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +686,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -608,6 +743,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,39 +772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "test-case-core",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +779,36 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -794,6 +932,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iptocc-py"
 description = "Python bindings for iptocc, a fast IP-to-country lookup library written in Rust"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iptocc-wasm"
 description = "WASM bindings for iptocc, a fast IP-to-country lookup library written in Rust"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roniemartinez/iptocc",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0",
   "description": "Fast, offline IP-to-country lookup. WASM bindings for the Rust iptocc crate.",
   "main": "pkg-nodejs/iptocc_wasm.js",
   "module": "pkg-bundler/iptocc_wasm.js",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iptocc"
 description = "Fast, offline IPv4/IPv6 address to ISO-3166 country code lookup using RIR delegated statistics"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 default-run = "iptocc"
 edition.workspace = true
 license.workspace = true

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 clap = { version = "4.6.0", features = ["derive"] }
 
 [dev-dependencies]
-test-case = "3.3.1"
+rstest = "0.26.1"
 criterion = "0.8.2"
 
 [[bench]]

--- a/crate/tests/api.rs
+++ b/crate/tests/api.rs
@@ -1,18 +1,19 @@
-use test_case::test_case;
+use rstest::rstest;
 
-#[test_case("41.0.0.1",               Some("ZA") ; "afrinic_v4")]
-#[test_case("2001:4200::1",           Some("ZA") ; "afrinic_v6")]
-#[test_case("1.0.16.1",               Some("JP") ; "apnic_v4")]
-#[test_case("2001:200::1",            Some("JP") ; "apnic_v6")]
-#[test_case("8.8.8.8",                Some("US") ; "arin_v4")]
-#[test_case("2001:4860:4860::8888",   Some("US") ; "arin_v6")]
-#[test_case("200.160.0.1",            Some("BR") ; "lacnic_v4")]
-#[test_case("2001:1280::1",           Some("BR") ; "lacnic_v6")]
-#[test_case("193.0.6.139",            Some("NL") ; "ripencc_v4")]
-#[test_case("2001:67c:18::1",         Some("NL") ; "ripencc_v6")]
-#[test_case("10.0.0.0",               None       ; "private_ipv4")]
-#[test_case("not-an-ip",              None       ; "malformed")]
-fn country_code_lookup(addr: &str, expected: Option<&str>) {
+#[rstest]
+#[case::afrinic_v4("41.0.0.1", Some("ZA"))]
+#[case::afrinic_v6("2001:4200::1", Some("ZA"))]
+#[case::apnic_v4("1.0.16.1", Some("JP"))]
+#[case::apnic_v6("2001:200::1", Some("JP"))]
+#[case::arin_v4("8.8.8.8", Some("US"))]
+#[case::arin_v6("2001:4860:4860::8888", Some("US"))]
+#[case::lacnic_v4("200.160.0.1", Some("BR"))]
+#[case::lacnic_v6("2001:1280::1", Some("BR"))]
+#[case::ripencc_v4("193.0.6.139", Some("NL"))]
+#[case::ripencc_v6("2001:67c:18::1", Some("NL"))]
+#[case::private_ipv4("10.0.0.0", None)]
+#[case::malformed("not-an-ip", None)]
+fn country_code_lookup(#[case] addr: &str, #[case] expected: Option<&str>) {
     assert_eq!(iptocc::country_code(addr), expected);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned Python bindings to stable release version 3.0.0
  * Transitioned WASM bindings to stable release version 1.0.0
  * Transitioned core library to stable release version 1.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->