### PR TITLE
fix(crate): resolve v4/v6 interval overlaps by clip-and-drop instead of erroring

### DIFF
--- a/crate/src/bin/generate-data.rs
+++ b/crate/src/bin/generate-data.rs
@@ -28,13 +28,21 @@ fn main() {
     let out_dir = Path::new(manifest_dir).join("src/data");
     fs::create_dir_all(&out_dir).expect("creating src/data");
 
-    let (mut v4, mut v6) = parse_rir(&data_dir);
+    let (v4, v6) = parse_rir(&data_dir);
+    let mut v4 = resolve_v4_overlaps(v4);
+    let mut v6 = resolve_v6_overlaps(v6);
 
     v4.sort_unstable_by_key(|t| t.start);
     v6.sort_unstable_by_key(|t| t.start);
 
-    assert!(v4.windows(2).all(|w| w[0].end < w[1].start), "v4 intervals overlap");
-    assert!(v6.windows(2).all(|w| w[0].end < w[1].start), "v6 intervals overlap");
+    assert!(
+        v4.windows(2).all(|w| w[0].end < w[1].start),
+        "v4 intervals still overlap after resolution"
+    );
+    assert!(
+        v6.windows(2).all(|w| w[0].end < w[1].start),
+        "v6 intervals still overlap after resolution"
+    );
 
     for entry in v4.iter().map(|e| e.cc).chain(v6.iter().map(|e| e.cc)) {
         assert!(
@@ -136,6 +144,61 @@ fn parse_rir(data_dir: &Path) -> (Vec<V4Interval>, Vec<V6Interval>) {
         }
     }
     (v4, v6)
+}
+
+// Sorts by start and resolves any overlaps by dropping or clipping earlier
+// intervals so the later one (in RIR iteration order, via stable sort) wins.
+// RIR data occasionally publishes duplicate or conflicting allocations when a
+// block is transferred between registries; the format requires disjoint
+// intervals, so we pick a deterministic winner rather than error out.
+fn resolve_v4_overlaps(mut intervals: Vec<V4Interval>) -> Vec<V4Interval> {
+    intervals.sort_by_key(|t| t.start);
+    let mut out: Vec<V4Interval> = Vec::with_capacity(intervals.len());
+    for entry in intervals {
+        while let Some(last) = out.last_mut() {
+            if last.end < entry.start {
+                break;
+            }
+            if last.start >= entry.start {
+                out.pop();
+            } else {
+                let clipped = entry.start - 1;
+                if clipped < last.start {
+                    out.pop();
+                } else {
+                    last.end = clipped;
+                    break;
+                }
+            }
+        }
+        out.push(entry);
+    }
+    out
+}
+
+fn resolve_v6_overlaps(mut intervals: Vec<V6Interval>) -> Vec<V6Interval> {
+    intervals.sort_by_key(|t| t.start);
+    let mut out: Vec<V6Interval> = Vec::with_capacity(intervals.len());
+    for entry in intervals {
+        while let Some(last) = out.last_mut() {
+            if last.end < entry.start {
+                break;
+            }
+            if last.start >= entry.start {
+                out.pop();
+            } else {
+                let clipped = entry.start - 1;
+                if clipped < last.start {
+                    out.pop();
+                } else {
+                    last.end = clipped;
+                    break;
+                }
+            }
+        }
+        out.push(entry);
+    }
+    out
 }
 
 fn transform_v4(intervals: &[V4Interval]) -> Vec<u8> {

--- a/crate/src/bin/generate-data.rs
+++ b/crate/src/bin/generate-data.rs
@@ -2,12 +2,23 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::ops::{Add, Sub};
 use std::path::Path;
 use std::str::FromStr;
 
 use iptocc::format::{FIRST_LEVEL_COUNT, V4_GAP_SENTINEL, V6_BUCKET_COUNT, V6_BUCKET_EMPTY, V6_SUB_INDEX_LEN};
 
 const RIRS: &[&str] = &["afrinic", "apnic", "arin", "lacnic", "ripencc"];
+
+trait Interval: Copy {
+    type Addr: Copy + Ord + Add<Output = Self::Addr> + Sub<Output = Self::Addr>;
+    const ONE: Self::Addr;
+    fn start(&self) -> Self::Addr;
+    fn end(&self) -> Self::Addr;
+    fn cc(&self) -> [u8; 2];
+    fn new(start: Self::Addr, end: Self::Addr, cc: [u8; 2]) -> Self;
+    fn set_end(&mut self, end: Self::Addr);
+}
 
 #[derive(Clone, Copy)]
 struct V4Interval {
@@ -23,6 +34,46 @@ struct V6Interval {
     cc: [u8; 2],
 }
 
+impl Interval for V4Interval {
+    type Addr = u32;
+    const ONE: u32 = 1;
+    fn start(&self) -> u32 {
+        self.start
+    }
+    fn end(&self) -> u32 {
+        self.end
+    }
+    fn cc(&self) -> [u8; 2] {
+        self.cc
+    }
+    fn new(start: u32, end: u32, cc: [u8; 2]) -> Self {
+        V4Interval { start, end, cc }
+    }
+    fn set_end(&mut self, end: u32) {
+        self.end = end;
+    }
+}
+
+impl Interval for V6Interval {
+    type Addr = u128;
+    const ONE: u128 = 1;
+    fn start(&self) -> u128 {
+        self.start
+    }
+    fn end(&self) -> u128 {
+        self.end
+    }
+    fn cc(&self) -> [u8; 2] {
+        self.cc
+    }
+    fn new(start: u128, end: u128, cc: [u8; 2]) -> Self {
+        V6Interval { start, end, cc }
+    }
+    fn set_end(&mut self, end: u128) {
+        self.end = end;
+    }
+}
+
 fn main() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let workspace_root = Path::new(manifest_dir).parent().expect("workspace root");
@@ -31,8 +82,8 @@ fn main() {
     fs::create_dir_all(&out_dir).expect("creating src/data");
 
     let (v4, v6) = parse_rir(&data_dir);
-    let mut v4 = resolve_v4_overlaps(v4);
-    let mut v6 = resolve_v6_overlaps(v6);
+    let mut v4 = resolve_overlaps(v4);
+    let mut v6 = resolve_overlaps(v6);
 
     v4.sort_unstable_by_key(|t| t.start);
     v6.sort_unstable_by_key(|t| t.start);
@@ -148,83 +199,27 @@ fn parse_rir(data_dir: &Path) -> (Vec<V4Interval>, Vec<V6Interval>) {
     (v4, v6)
 }
 
-fn resolve_v4_overlaps(mut intervals: Vec<V4Interval>) -> Vec<V4Interval> {
-    intervals.sort_by_key(|t| t.start);
-    let mut out: Vec<V4Interval> = Vec::with_capacity(intervals.len());
+fn resolve_overlaps<I: Interval>(mut intervals: Vec<I>) -> Vec<I> {
+    intervals.sort_by_key(|t| t.start());
+    let mut out: Vec<I> = Vec::with_capacity(intervals.len());
     for entry in intervals {
-        let mut handled = false;
+        let mut tail: Option<I> = None;
         while let Some(&last) = out.last() {
-            if last.end < entry.start {
+            if last.end() < entry.start() {
                 break;
             }
-            if last.start < entry.start {
-                out.last_mut().unwrap().end = entry.start - 1;
-                if last.end > entry.end {
-                    out.push(entry);
-                    out.push(V4Interval {
-                        start: entry.end + 1,
-                        end: last.end,
-                        cc: last.cc,
-                    });
-                    handled = true;
-                }
+            if last.end() > entry.end() && tail.is_none() {
+                tail = Some(I::new(entry.end() + I::ONE, last.end(), last.cc()));
+            }
+            if last.start() < entry.start() {
+                out.last_mut().unwrap().set_end(entry.start() - I::ONE);
                 break;
             }
             out.pop();
-            if last.end > entry.end {
-                out.push(entry);
-                out.push(V4Interval {
-                    start: entry.end + 1,
-                    end: last.end,
-                    cc: last.cc,
-                });
-                handled = true;
-                break;
-            }
         }
-        if !handled {
-            out.push(entry);
-        }
-    }
-    out
-}
-
-fn resolve_v6_overlaps(mut intervals: Vec<V6Interval>) -> Vec<V6Interval> {
-    intervals.sort_by_key(|t| t.start);
-    let mut out: Vec<V6Interval> = Vec::with_capacity(intervals.len());
-    for entry in intervals {
-        let mut handled = false;
-        while let Some(&last) = out.last() {
-            if last.end < entry.start {
-                break;
-            }
-            if last.start < entry.start {
-                out.last_mut().unwrap().end = entry.start - 1;
-                if last.end > entry.end {
-                    out.push(entry);
-                    out.push(V6Interval {
-                        start: entry.end + 1,
-                        end: last.end,
-                        cc: last.cc,
-                    });
-                    handled = true;
-                }
-                break;
-            }
-            out.pop();
-            if last.end > entry.end {
-                out.push(entry);
-                out.push(V6Interval {
-                    start: entry.end + 1,
-                    end: last.end,
-                    cc: last.cc,
-                });
-                handled = true;
-                break;
-            }
-        }
-        if !handled {
-            out.push(entry);
+        out.push(entry);
+        if let Some(t) = tail {
+            out.push(t);
         }
     }
     out

--- a/crate/src/bin/generate-data.rs
+++ b/crate/src/bin/generate-data.rs
@@ -9,12 +9,14 @@ use iptocc::format::{FIRST_LEVEL_COUNT, V4_GAP_SENTINEL, V6_BUCKET_COUNT, V6_BUC
 
 const RIRS: &[&str] = &["afrinic", "apnic", "arin", "lacnic", "ripencc"];
 
+#[derive(Clone, Copy)]
 struct V4Interval {
     start: u32,
     end: u32,
     cc: [u8; 2],
 }
 
+#[derive(Clone, Copy)]
 struct V6Interval {
     start: u128,
     end: u128,
@@ -146,32 +148,43 @@ fn parse_rir(data_dir: &Path) -> (Vec<V4Interval>, Vec<V6Interval>) {
     (v4, v6)
 }
 
-// Sorts by start and resolves any overlaps by dropping or clipping earlier
-// intervals so the later one (in RIR iteration order, via stable sort) wins.
-// RIR data occasionally publishes duplicate or conflicting allocations when a
-// block is transferred between registries; the format requires disjoint
-// intervals, so we pick a deterministic winner rather than error out.
 fn resolve_v4_overlaps(mut intervals: Vec<V4Interval>) -> Vec<V4Interval> {
     intervals.sort_by_key(|t| t.start);
     let mut out: Vec<V4Interval> = Vec::with_capacity(intervals.len());
     for entry in intervals {
-        while let Some(last) = out.last_mut() {
+        let mut handled = false;
+        while let Some(&last) = out.last() {
             if last.end < entry.start {
                 break;
             }
-            if last.start >= entry.start {
-                out.pop();
-            } else {
-                let clipped = entry.start - 1;
-                if clipped < last.start {
-                    out.pop();
-                } else {
-                    last.end = clipped;
-                    break;
+            if last.start < entry.start {
+                out.last_mut().unwrap().end = entry.start - 1;
+                if last.end > entry.end {
+                    out.push(entry);
+                    out.push(V4Interval {
+                        start: entry.end + 1,
+                        end: last.end,
+                        cc: last.cc,
+                    });
+                    handled = true;
                 }
+                break;
+            }
+            out.pop();
+            if last.end > entry.end {
+                out.push(entry);
+                out.push(V4Interval {
+                    start: entry.end + 1,
+                    end: last.end,
+                    cc: last.cc,
+                });
+                handled = true;
+                break;
             }
         }
-        out.push(entry);
+        if !handled {
+            out.push(entry);
+        }
     }
     out
 }
@@ -180,23 +193,39 @@ fn resolve_v6_overlaps(mut intervals: Vec<V6Interval>) -> Vec<V6Interval> {
     intervals.sort_by_key(|t| t.start);
     let mut out: Vec<V6Interval> = Vec::with_capacity(intervals.len());
     for entry in intervals {
-        while let Some(last) = out.last_mut() {
+        let mut handled = false;
+        while let Some(&last) = out.last() {
             if last.end < entry.start {
                 break;
             }
-            if last.start >= entry.start {
-                out.pop();
-            } else {
-                let clipped = entry.start - 1;
-                if clipped < last.start {
-                    out.pop();
-                } else {
-                    last.end = clipped;
-                    break;
+            if last.start < entry.start {
+                out.last_mut().unwrap().end = entry.start - 1;
+                if last.end > entry.end {
+                    out.push(entry);
+                    out.push(V6Interval {
+                        start: entry.end + 1,
+                        end: last.end,
+                        cc: last.cc,
+                    });
+                    handled = true;
                 }
+                break;
+            }
+            out.pop();
+            if last.end > entry.end {
+                out.push(entry);
+                out.push(V6Interval {
+                    start: entry.end + 1,
+                    end: last.end,
+                    cc: last.cc,
+                });
+                handled = true;
+                break;
             }
         }
-        out.push(entry);
+        if !handled {
+            out.push(entry);
+        }
     }
     out
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deterministic resolution of overlapping IPv4 and IPv6 address intervals so generated datasets contain disjoint, non-conflicting ranges.
  * Incoming ranges now take precedence when overlaps occur; existing ranges are clipped or split to eliminate conflicts.
  * Improved validation and clearer reporting to assert and surface any remaining overlap issues during generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->