### PR TITLE
chore(deps): bump taiki-e/install-action from 2.77.1 to 2.77.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo clippy --target wasm32-unknown-unknown -p iptocc-wasm --lib -- -D warnings
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2.77.1
+        uses: taiki-e/install-action@v2.77.6
         with:
           tool: cargo-deny
 
@@ -97,7 +97,7 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2.9.1
-      - uses: taiki-e/install-action@v2.77.1
+      - uses: taiki-e/install-action@v2.77.6
         with:
           tool: wasm-pack
       - uses: actions/setup-node@v6.4.0

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
-      - uses: taiki-e/install-action@v2.77.1
+      - uses: taiki-e/install-action@v2.77.6
         with:
           tool: wasm-pack
       - uses: actions/setup-node@v6.4.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependency used by CI and publish workflows to improve Rust/wasm toolchain installation stability and performance. Change is low-risk and does not alter build logic or release behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roniemartinez/IPToCC/pull/36)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roniemartinez/IPToCC/pull/36)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->