### PR TITLE
perf: single-pass IP parser, and stop allocating a string per Python lookup

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,5 +1,43 @@
+use std::sync::OnceLock;
+
 use pyo3::prelude::*;
-use pyo3::types::PyString;
+use pyo3::types::{PyList, PyString, PyTuple};
+
+/// One slot per pair of ASCII uppercase letters. The data generator guarantees
+/// every country code is exactly that, so this indexes without hashing.
+const CC_SLOTS: usize = 26 * 26;
+
+/// Interned `str` objects for the country codes, built once at module import.
+///
+/// Without this, every hit allocated a fresh two-character `PyUnicode`; a lookup
+/// that costs single-digit nanoseconds in Rust should not be paying for an object
+/// allocation to report its answer. Returning a cached object is one incref.
+static CC_CACHE: OnceLock<Box<[Option<Py<PyString>>; CC_SLOTS]>> = OnceLock::new();
+
+#[inline]
+fn cc_slot(cc: &str) -> usize {
+    let b = cc.as_bytes();
+    (b[0] - b'A') as usize * 26 + (b[1] - b'A') as usize
+}
+
+#[inline]
+fn to_py<'py>(py: Python<'py>, cc: Option<&'static str>) -> Bound<'py, PyAny> {
+    match cc {
+        Some(cc) => match CC_CACHE.get().and_then(|cache| cache[cc_slot(cc)].as_ref()) {
+            Some(cached) => cached.bind(py).clone().into_any(),
+            // Unreachable while the cache is built from `country_code_set`, but
+            // a fresh string is a correct answer either way.
+            None => PyString::new(py, cc).into_any(),
+        },
+        None => py.None().into_bound(py),
+    }
+}
+
+#[inline]
+fn lookup_item<'py>(py: Python<'py>, item: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    let s = item.cast::<PyString>()?.to_str()?;
+    Ok(to_py(py, ::iptocc::country_code(s)))
+}
 
 /// Looks up the ISO 3166-1 alpha-2 country code for an IPv4 or IPv6 address.
 ///
@@ -9,20 +47,47 @@ use pyo3::types::PyString;
 #[pyfunction]
 fn country_code<'py>(py: Python<'py>, input: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
     if let Ok(pystr) = input.cast::<PyString>() {
-        return Ok(::iptocc::country_code(pystr.to_str()?).into_pyobject(py)?.into_any());
+        return Ok(to_py(py, ::iptocc::country_code(pystr.to_str()?)));
     }
-    let len_hint = input.len().unwrap_or(0);
-    let mut results: Vec<Option<&'static str>> = Vec::with_capacity(len_hint);
+
+    // Lists and tuples are the overwhelmingly common batch shapes and can be
+    // indexed directly, skipping the iterator protocol's per-item call. Exact
+    // types only: a subclass may override __iter__, and the slow path honours it.
+    if let Ok(list) = input.cast_exact::<PyList>() {
+        let mut results = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            results.push(lookup_item(py, &item)?);
+        }
+        return Ok(PyList::new(py, results)?.into_any());
+    }
+    if let Ok(tuple) = input.cast_exact::<PyTuple>() {
+        let mut results = Vec::with_capacity(tuple.len());
+        for item in tuple.iter() {
+            results.push(lookup_item(py, &item)?);
+        }
+        return Ok(PyList::new(py, results)?.into_any());
+    }
+
+    let mut results = Vec::with_capacity(input.len().unwrap_or(0));
     for item in input.try_iter()? {
-        let item = item?;
-        let s = item.cast::<PyString>()?.to_str()?;
-        results.push(::iptocc::country_code(s));
+        results.push(lookup_item(py, &item?)?);
     }
-    Ok(results.into_pyobject(py)?.into_any())
+    Ok(PyList::new(py, results)?.into_any())
 }
 
 #[pymodule]
 fn iptocc(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
+    CC_CACHE.get_or_init(|| {
+        let mut cache: Box<[Option<Py<PyString>>; CC_SLOTS]> = Box::new(core::array::from_fn(|_| None));
+        for cc in ::iptocc::country_code_set() {
+            let slot = &mut cache[cc_slot(cc)];
+            if slot.is_none() {
+                *slot = Some(PyString::intern(py, cc).unbind());
+            }
+        }
+        cache
+    });
     m.add_function(wrap_pyfunction!(country_code, m)?)?;
     Ok(())
 }

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,10 +1,10 @@
 //! Fast offline IP-to-country lookup using RIR delegated statistics.
 
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use core::str::FromStr;
 
 #[doc(hidden)]
 pub mod format;
+mod parse;
 
 use format::{
     BUCKET_COUNT, TAG_EMPTY, TAG_MASK, TAG_PURE, UNASSIGNED, V4_DEEP_TOP4_LEN, V6_BYTE_INDEX_LEN, V6_DENSE_THRESHOLD,
@@ -16,6 +16,7 @@ static V6_BIN: &[u8] = include_bytes!("data/v6.bin");
 
 struct V4Layout {
     cc_dict: usize,
+    cc_count: usize,
     mixed_base: usize,
     mixed_initial: usize,
     transition_offsets: usize,
@@ -36,6 +37,7 @@ struct V6Layout {
     deep_32: DeepIndex,
     deep_40: DeepIndex,
     cc_dict: usize,
+    cc_count: usize,
     side: usize,
     primary: usize,
 }
@@ -57,6 +59,7 @@ const V4: V4Layout = {
     let deep_narrow = dense_count_at + 4;
     V4Layout {
         cc_dict,
+        cc_count: cc_dict_count,
         mixed_base,
         mixed_initial,
         transition_offsets,
@@ -93,6 +96,7 @@ const V6: V6Layout = {
         deep_32,
         deep_40,
         cc_dict,
+        cc_count: cc_dict_count,
         side,
         primary,
     }
@@ -118,7 +122,7 @@ impl sealed::Sealed for &str {}
 impl IpAddress for &str {
     #[inline]
     fn lookup(self) -> Option<&'static str> {
-        IpAddr::from_str(self).ok().and_then(IpAddress::lookup)
+        parse::parse_ip(self).and_then(IpAddress::lookup)
     }
 }
 
@@ -184,6 +188,19 @@ where
     T: IpAddress,
 {
     inputs.into_iter().map(IpAddress::lookup).collect()
+}
+
+/// Every country code the embedded data can return. May yield a code twice, since
+/// the IPv4 and IPv6 dictionaries are independent.
+///
+/// Exposed for bindings that pre-build a per-code object cache at load time:
+/// `country_code` only ever returns one of these strings, so such a cache is
+/// guaranteed complete.
+#[doc(hidden)]
+pub fn country_code_set() -> impl Iterator<Item = &'static str> {
+    let v4 = (0..V4.cc_count).map(|i| cc_from_dict(V4_BIN, V4.cc_dict, i as u8));
+    let v6 = (0..V6.cc_count).map(|i| cc_from_dict(V6_BIN, V6.cc_dict, i as u8));
+    v4.chain(v6)
 }
 
 #[inline]

--- a/crate/src/parse.rs
+++ b/crate/src/parse.rs
@@ -1,0 +1,312 @@
+//! Single-pass IP address parsing.
+//!
+//! `core::net`'s `FromStr` is a backtracking parser shared by socket-address and
+//! CIDR syntax; addresses arrive here already isolated, so a straight-line scan
+//! does the same job in a fraction of the work. Accepts exactly the same set of
+//! strings as `IpAddr::from_str` — including its rejection of leading zeros in
+//! IPv4 octets — which `parity_with_std` in the test module pins down.
+
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+#[inline]
+pub fn parse_ip(s: &str) -> Option<IpAddr> {
+    let b = s.as_bytes();
+    // The grammars are disjoint, so trying IPv4 first costs nothing to reject: a
+    // v6 literal fails within the first few bytes (on ':' or a fifth hex digit).
+    // Scanning ahead for a ':' to pick the branch measured slower — the scan is a
+    // whole extra pass over the common, short, IPv4 case.
+    if let Some(bits) = parse_v4(b) {
+        return Some(IpAddr::V4(Ipv4Addr::from_bits(bits)));
+    }
+    parse_v6(b).map(|bits| IpAddr::V6(Ipv6Addr::from_bits(bits)))
+}
+
+/// Parses a dotted-quad into host-order bits. Rejects leading zeros, matching std.
+#[inline]
+fn parse_v4(b: &[u8]) -> Option<u32> {
+    let mut result = 0u32;
+    let mut i = 0usize;
+
+    for octet in 0..4 {
+        if octet > 0 {
+            if b.get(i) != Some(&b'.') {
+                return None;
+            }
+            i += 1;
+        }
+
+        let start = i;
+        let mut value = 0u32;
+        while i < b.len() && b[i].is_ascii_digit() {
+            // Bail on the fourth digit rather than after the loop: an unbounded
+            // run of digits would otherwise overflow `value`.
+            if i - start == 3 {
+                return None;
+            }
+            value = value * 10 + (b[i] - b'0') as u32;
+            i += 1;
+        }
+
+        let len = i - start;
+        if len == 0 || value > 255 {
+            return None;
+        }
+        if len > 1 && b[start] == b'0' {
+            return None;
+        }
+        result = (result << 8) | value;
+    }
+
+    (i == b.len()).then_some(result)
+}
+
+/// Parses an IPv6 literal, including `::` compression and an embedded IPv4 tail.
+fn parse_v6(b: &[u8]) -> Option<u128> {
+    let mut groups = [0u16; 8];
+    let mut filled = 0usize;
+    let mut ellipsis: Option<usize> = None;
+    let mut i = 0usize;
+
+    // A leading ':' is only legal as the first half of "::".
+    if b.first() == Some(&b':') {
+        if b.get(1) != Some(&b':') {
+            return None;
+        }
+        ellipsis = Some(0);
+        i = 2;
+        if i == b.len() {
+            return Some(0); // "::"
+        }
+    }
+
+    loop {
+        if filled == 8 {
+            return None;
+        }
+
+        let start = i;
+        let mut value = 0u32;
+        while i < b.len() {
+            let digit = match b[i] {
+                c @ b'0'..=b'9' => c - b'0',
+                c @ b'a'..=b'f' => c - b'a' + 10,
+                c @ b'A'..=b'F' => c - b'A' + 10,
+                _ => break,
+            };
+            value = (value << 4) | digit as u32;
+            i += 1;
+            if i - start > 4 {
+                return None;
+            }
+        }
+        if i == start {
+            return None;
+        }
+
+        // A '.' means this run of digits was really the start of an IPv4 tail,
+        // which occupies the last two groups and ends the address.
+        if b.get(i) == Some(&b'.') {
+            if filled > 6 {
+                return None;
+            }
+            let v4 = parse_v4(&b[start..])?;
+            groups[filled] = (v4 >> 16) as u16;
+            groups[filled + 1] = v4 as u16;
+            filled += 2;
+            break; // parse_v4 already required the tail to reach the end
+        }
+
+        groups[filled] = value as u16;
+        filled += 1;
+
+        if i == b.len() {
+            break;
+        }
+        if b[i] != b':' {
+            return None;
+        }
+        i += 1;
+
+        if b.get(i) == Some(&b':') {
+            if ellipsis.is_some() {
+                return None;
+            }
+            ellipsis = Some(filled);
+            i += 1;
+            if i == b.len() {
+                break; // trailing "::"
+            }
+        } else if i == b.len() {
+            return None; // dangling ':'
+        }
+    }
+
+    match ellipsis {
+        // Without compression every group must be spelled out.
+        None => {
+            if filled != 8 {
+                return None;
+            }
+        }
+        // "::" has to stand for at least one group, so a full set is a conflict.
+        Some(at) => {
+            if filled == 8 {
+                return None;
+            }
+            let tail = filled - at;
+            let dst = 8 - tail;
+            for k in (0..tail).rev() {
+                groups[dst + k] = groups[at + k];
+            }
+            for slot in &mut groups[at..dst] {
+                *slot = 0;
+            }
+        }
+    }
+
+    let mut bits = 0u128;
+    for group in groups {
+        bits = (bits << 16) | group as u128;
+    }
+    Some(bits)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    /// Every string below must parse (or fail) identically to `IpAddr::from_str`.
+    /// This is the whole safety net for replacing std's parser.
+    #[test]
+    fn parity_with_std() {
+        let mut cases: Vec<String> = Vec::new();
+
+        for s in [
+            // v4: valid, boundary, and malformed
+            "0.0.0.0",
+            "255.255.255.255",
+            "8.8.8.8",
+            "1.0.16.1",
+            "10.0.0.0",
+            "256.0.0.1",
+            "1.2.3",
+            "1.2.3.4.5",
+            "1.2.3.",
+            ".1.2.3",
+            "01.2.3.4",
+            "1.02.3.4",
+            "0.0.0.00",
+            "1.2.3.4 ",
+            " 1.2.3.4",
+            "1.2.3.-4",
+            "1..2.3",
+            "1.2.3.4a",
+            "",
+            "not-an-ip",
+            // v6: compression in every position
+            "::",
+            "::1",
+            "1::",
+            "::ffff",
+            "1:2:3:4:5:6:7:8",
+            "1:2:3:4:5:6:7::",
+            "1::8",
+            "1:2::8",
+            "1:2:3:4:5:6::8",
+            "2001:4860:4860::8888",
+            "2001:67c:18::1",
+            "2001:db8:0:0:0:0:0:1",
+            "0000:0000:0000:0000:0000:0000:0000:0001",
+            "fe80::1%eth0",
+            // v6: embedded v4
+            "::ffff:192.168.0.1",
+            "::192.168.0.1",
+            "64:ff9b::1.2.3.4",
+            "1:2:3:4:5:6:1.2.3.4",
+            "1:2:3:4:5:6:7:1.2.3.4",
+            "::ffff:1.2.3.4:5",
+            "::ffff:256.1.1.1",
+            "::ffff:01.2.3.4",
+            // v6: malformed
+            "1:2:3:4:5:6:7:8:9",
+            "1:2:3:4:5:6:7",
+            "1::2::3",
+            "1:2:3:4::5:6:7:8",
+            ":1:2:3:4:5:6:7",
+            "1:2:3:4:5:6:7:",
+            ":::",
+            "12345::",
+            "1:2:3:4:5:6:7:8::",
+            "::1:2:3:4:5:6:7:8",
+            "g::1",
+            "1:2:3:4:5:6:7:8 ",
+            "1:",
+            ":",
+            "::.",
+            "1::2:",
+        ] {
+            cases.push(s.to_string());
+        }
+
+        // Exhaustive small-alphabet fuzz: every string up to length 4 over the
+        // characters that matter for both grammars.
+        let alphabet = b"0129afAF:.";
+        for len in 0..=4 {
+            let mut indices = vec![0usize; len];
+            loop {
+                cases.push(indices.iter().map(|&i| alphabet[i] as char).collect());
+                let mut pos = 0;
+                while pos < len {
+                    indices[pos] += 1;
+                    if indices[pos] < alphabet.len() {
+                        break;
+                    }
+                    indices[pos] = 0;
+                    pos += 1;
+                }
+                if pos == len {
+                    break;
+                }
+            }
+        }
+
+        // Structured pseudo-random strings, biased toward near-valid addresses.
+        let mut seed = 0x2545_F491_4F6C_DD1Du64;
+        let mut next = move || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        for _ in 0..200_000 {
+            let len = (next() % 44) as usize + 1;
+            let s: String = (0..len)
+                .map(|_| alphabet[(next() % alphabet.len() as u64) as usize] as char)
+                .collect();
+            cases.push(s);
+        }
+        for _ in 0..50_000 {
+            let a = next();
+            cases.push(format!(
+                "{}.{}.{}.{}",
+                a as u8,
+                (a >> 8) as u8,
+                (a >> 16) as u8,
+                (a >> 24) as u8
+            ));
+            let b = next();
+            cases.push(format!("{:x}:{:x}::{:x}", a as u16, (a >> 16) as u16, b as u16));
+            cases.push(Ipv6Addr::from_bits(((a as u128) << 64) | b as u128).to_string());
+        }
+
+        for case in &cases {
+            assert_eq!(
+                parse_ip(case),
+                IpAddr::from_str(case).ok(),
+                "parser disagrees with std on {case:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two independent performance changes.

**1. `crate`: replace `IpAddr::from_str` with a single-pass parser.** std's parser backtracks and is shared with socket-address/CIDR syntax; addresses reach `country_code` already isolated, so a straight-line scan does the same job in far less work. For IPv6 string input, *parsing was the dominant cost, not lookup*.

**2. `bindings/python`: stop allocating a `PyUnicode` per hit, and index list/tuple batches directly.** Every hit was allocating a fresh two-character string to report its answer, costing more than the lookup that produced it. The reachable country codes are a small fixed set, so they're interned once at import into a table indexed by the two ASCII letters. Batch calls also skip the generic iterator protocol for exact `list`/`tuple`.

## Numbers

Windows/x86_64, CPython 3.11 — different machine from `BENCHMARK.md`

Parser, head to head in one binary (Criterion):

| | std | this PR |
|---|---:|---:|
| v6 typical | 60–82 ns | 18–26 ns |
| v6 full form | 105 ns | 40 ns |
| v4 | 15–23 ns | 10–14 ns |

Rust core end to end via `country_code(&str)`, vs. saved baseline: **IPv6 −53% to −71%, IPv4 −13% to −29%**.

Python binding, old vs new:

| case | delta |
|---|---:|
| single call, IPv6 | −41% to −45% |
| single call, IPv4 | −26% to −31% |
| batch, per address | −33% to −37% |

## How the Python numbers were measured

Both `.pyd` builds are loaded into **one process** under distinct module names and alternated every trial, pinned to one core at high priority, using `min` across trials (medians swung ±15% at this scale).

An **A/A control** — the same binary measured against itself — gives ±4% with p > 0.1. That's the noise floor these deltas sit against. In 14 of 16 cases the new build's *slowest* trial beat the old build's *fastest*.

## Correctness

- `parity_with_std` asserts identical accept/reject behaviour against `IpAddr::from_str` over ~350k inputs: hand-picked edge cases, **exhaustively** every string up to length 4 over the alphabet that matters for both grammars, and structured fuzz. This pins std's rejection of leading zeros in IPv4 octets and of IPv6 zone IDs.
- The new binding was diffed against the old one over 15k single calls and 2035 batch calls across five container shapes, plus subclasses, bad element types, and an iterable that raises mid-iteration — no differences in values, types, or raised exceptions.
- `cargo test` (debug **and** release), `cargo fmt --check`, CI's exact `cargo clippy ... -D warnings` for both the workspace and the wasm target all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering all country codes available in the IPv4 and IPv6 databases.
  * Improved Python lookup results, including consistent handling of missing addresses and batch results.
* **Bug Fixes**
  * Improved validation for IPv4 and IPv6 addresses, including compressed IPv6 notation and embedded IPv4 addresses.
  * Invalid addresses, malformed octets, leading zeros, and incorrect hexadecimal formats are now rejected consistently.
* **Performance**
  * Repeated Python country-code results are now handled more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->