### PR TITLE
fix(wasm): correct exports condition order for Node ESM, Deno and bundlers

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,14 +1,17 @@
 # Benchmarks
 
 Per-call latency for `country_code(address)`, one well-known IP per RIR plus one negative case per protocol.
+Batch tables cycle those same addresses to length N.
 
 ## Reference machine
 
 |                      |                                |
 | -------------------- | ------------------------------ |
 | Model                | Apple M3 Pro (11-core), 18 GiB |
-| OS                   | macOS 26.3.1                   |
-| Rust / Python / Node | 1.95.0 / 3.14.3 / 22.15.0      |
+| OS                   | macOS 26.6.2                   |
+| Rust / Python / Node | 1.98.1 / 3.14.3 / 22.15.0      |
+
+Rust figures are Criterion point estimates, Python pytest-benchmark means, WASM medians of 7 mitata runs.
 
 ## Rust core (Criterion)
 
@@ -16,23 +19,41 @@ String input via `country_code(&str)`:
 
 | Case                                        |    IPv4 |    IPv6 |
 | ------------------------------------------- | ------: | ------: |
-| AFRINIC `41.0.0.1` / `2001:4200::1`         |  5.6 ns | 39.2 ns |
-| APNIC `1.0.16.1` / `2001:200::1`            |  8.4 ns | 39.4 ns |
-| ARIN `8.8.8.8` / `2001:4860:4860::8888`     |  5.6 ns | 49.4 ns |
-| LACNIC `200.160.0.1` / `2001:1280::1`       |  6.6 ns | 39.1 ns |
-| RIPE NCC `193.0.6.139` / `2001:67c:18::1`   |  7.8 ns | 51.2 ns |
-| miss `10.0.0.0` / `::1`                     |  5.6 ns | 16.0 ns |
+| AFRINIC `41.0.0.1` / `2001:4200::1`         |  5.9 ns | 32.4 ns |
+| APNIC `1.0.16.1` / `2001:200::1`            |  7.7 ns | 29.0 ns |
+| ARIN `8.8.8.8` / `2001:4860:4860::8888`     |  5.3 ns | 39.6 ns |
+| LACNIC `200.160.0.1` / `2001:1280::1`       |  6.2 ns | 32.4 ns |
+| RIPE NCC `193.0.6.139` / `2001:67c:18::1`   |  6.9 ns | 47.1 ns |
+| miss `10.0.0.0` / `::1`                     |  5.6 ns | 12.3 ns |
 
 Typed input via `country_code(Ipv4Addr)` / `country_code(Ipv6Addr)`:
 
 | Case     |   IPv4 |    IPv6 |
 | -------- | -----: | ------: |
 | AFRINIC  | 1.3 ns |  9.7 ns |
-| APNIC    | 3.6 ns |  9.3 ns |
-| ARIN     | 1.3 ns |  9.7 ns |
-| LACNIC   | 1.3 ns |  9.8 ns |
-| RIPE NCC | 2.7 ns | 13.3 ns |
+| APNIC    | 3.8 ns |  9.0 ns |
+| ARIN     | 1.3 ns |  9.9 ns |
+| LACNIC   | 1.3 ns | 10.5 ns |
+| RIPE NCC | 2.4 ns | 14.2 ns |
 | miss     | 1.1 ns |  1.1 ns |
+
+Batch call, `country_codes(iterable_of_N)`, string input:
+
+|      N |     IPv4 | Per address |      IPv6 | Per address |
+| -----: | -------: | ----------: | --------: | ----------: |
+|     10 |  99.4 ns |      9.9 ns |  404.7 ns |     40.5 ns |
+|    100 | 816.2 ns |      8.2 ns |   3.73 us |     37.3 ns |
+|  1,000 |  8.01 us |      8.0 ns |  37.08 us |     37.1 ns |
+| 10,000 | 79.40 us |      7.9 ns | 375.59 us |     37.6 ns |
+
+Batch call, typed input:
+
+|      N |     IPv4 | Per address |      IPv6 | Per address |
+| -----: | -------: | ----------: | --------: | ----------: |
+|     10 |  44.3 ns |      4.4 ns |  143.3 ns |     14.3 ns |
+|    100 | 269.6 ns |      2.7 ns |   1.24 us |     12.4 ns |
+|  1,000 |  2.58 us |      2.6 ns |  12.15 us |     12.1 ns |
+| 10,000 | 24.94 us |      2.5 ns | 121.27 us |     12.1 ns |
 
 ```bash
 task bench:rust
@@ -44,21 +65,21 @@ Single-call latency:
 
 | Case     |     IPv4 |     IPv6 |
 | -------- | -------: | -------: |
-| AFRINIC  |  92.1 ns | 131.5 ns |
-| APNIC    | 100.6 ns | 133.9 ns |
-| ARIN     |  44.6 ns |  96.7 ns |
-| LACNIC   |  96.0 ns | 130.6 ns |
-| RIPE NCC |  98.9 ns | 152.0 ns |
-| miss     |  35.3 ns |  45.9 ns |
+| AFRINIC  |  42.9 ns | 121.0 ns |
+| APNIC    |  96.9 ns |  81.6 ns |
+| ARIN     |  42.2 ns | 132.0 ns |
+| LACNIC   |  44.5 ns |  81.2 ns |
+| RIPE NCC |  93.9 ns | 127.5 ns |
+| miss     |  34.6 ns |  42.3 ns |
 
 Batch call, `country_code(list_of_N)`:
 
-|      N |    Total | Per address |
-| -----: | -------: | ----------: |
-|     10 |   325 ns |     32.5 ns |
-|    100 |  2.49 us |     24.9 ns |
-|  1,000 |  23.6 us |     23.6 ns |
-| 10,000 | 249.9 us |     25.0 ns |
+|      N |     Total | Per address |
+| -----: | --------: | ----------: |
+|     10 |  332.6 ns |     33.3 ns |
+|    100 |   2.47 us |     24.7 ns |
+|  1,000 |  23.63 us |     23.6 ns |
+| 10,000 | 253.54 us |     25.4 ns |
 
 ```bash
 task bench:python
@@ -66,14 +87,25 @@ task bench:python
 
 ## WASM binding (mitata)
 
+Single-call latency:
+
 | Case     |     IPv4 |     IPv6 |
 | -------- | -------: | -------: |
-| AFRINIC  | 190.2 ns | 279.0 ns |
-| APNIC    | 206.1 ns | 275.4 ns |
-| ARIN     | 191.8 ns | 301.5 ns |
-| LACNIC   | 198.9 ns | 275.6 ns |
-| RIPE NCC | 205.1 ns | 296.6 ns |
-| miss     | 103.8 ns | 121.9 ns |
+| AFRINIC  | 181.4 ns | 251.3 ns |
+| APNIC    | 195.1 ns | 251.8 ns |
+| ARIN     | 181.2 ns | 270.9 ns |
+| LACNIC   | 189.6 ns | 251.7 ns |
+| RIPE NCC | 194.6 ns | 270.2 ns |
+| miss     |  98.8 ns | 113.2 ns |
+
+Batch call, `country_code(array_of_N)`:
+
+|      N |      IPv4 | Per address |      IPv6 | Per address |
+| -----: | --------: | ----------: | --------: | ----------: |
+|     10 |   1.80 us |    180.0 ns |   2.39 us |    239.0 ns |
+|    100 |  16.51 us |    165.1 ns |  22.16 us |    221.6 ns |
+|  1,000 | 162.59 us |    162.6 ns | 220.07 us |    220.1 ns |
+| 10,000 |   1.66 ms |    166.0 ns |   2.19 ms |    219.0 ns |
 
 ```bash
 task bench:wasm

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ assert_eq!(codes, vec![Some("US"), Some("JP"), None]);
 ### Node
 
 ```javascript
+// ESM
+import { country_code } from "@roniemartinez/iptocc";
+
+// CommonJS
 const { country_code } = require("@roniemartinez/iptocc");
 
 country_code("8.8.8.8");                     // "US"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Fast, offline IPv4/IPv6 to ISO 3166-1 alpha-2 country code lookup. One Rust core
 - IPv4 and IPv6 in a single call.
 - Accepts a single address or a batch of addresses.
 - Lookup data embedded in the binary; no runtime file I/O.
-- ~1-13 ns on native Rust (typed input); ~44-141 ns through Python, ~200-300 ns through WASM.
+- ~1-14 ns on native Rust (typed input); ~35-132 ns through Python, ~99-271 ns through WASM.
 - `iptocc` CLI installed via `pip`, `cargo`, or `npm`.
 - Data refreshed nightly from the five Regional Internet Registries.
 
@@ -80,10 +80,13 @@ assert_eq!(codes, vec![Some("US"), Some("JP"), None]);
 ### Node
 
 ```javascript
-// ESM
 import { country_code } from "@roniemartinez/iptocc";
 
-// CommonJS
+country_code("8.8.8.8");                     // "US"
+country_code(["8.8.8.8", "1.0.16.1"]);       // ["US", "JP"]
+```
+
+```javascript
 const { country_code } = require("@roniemartinez/iptocc");
 
 country_code("8.8.8.8");                     // "US"

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -25,6 +25,10 @@ npm install @roniemartinez/iptocc
 ## Usage
 
 ```javascript
+// ESM
+import { country_code } from "@roniemartinez/iptocc";
+
+// CommonJS
 const { country_code } = require("@roniemartinez/iptocc");
 
 country_code("8.8.8.8");                  // "US"

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -25,10 +25,13 @@ npm install @roniemartinez/iptocc
 ## Usage
 
 ```javascript
-// ESM
 import { country_code } from "@roniemartinez/iptocc";
 
-// CommonJS
+country_code("8.8.8.8");                  // "US"
+country_code(["8.8.8.8", "1.0.16.1"]);    // ["US", "JP"]
+```
+
+```javascript
 const { country_code } = require("@roniemartinez/iptocc");
 
 country_code("8.8.8.8");                  // "US"

--- a/bindings/wasm/benchmarks/bench_lookup.mjs
+++ b/bindings/wasm/benchmarks/bench_lookup.mjs
@@ -19,6 +19,11 @@ const V6 = [
   ["miss_loopback", "::1"],
 ];
 
+for (let i = 0; i < 200000; i++) {
+  for (const [, addr] of V4) country_code(addr);
+  for (const [, addr] of V6) country_code(addr);
+}
+
 group("v4", () => {
   for (const [name, addr] of V4) {
     bench(name, () => country_code(addr));
@@ -28,6 +33,30 @@ group("v4", () => {
 group("v6", () => {
   for (const [name, addr] of V6) {
     bench(name, () => country_code(addr));
+  }
+});
+
+const BATCH_SIZES = [10, 100, 1000, 10000];
+
+const repeat = (cases, n) => {
+  const addrs = [];
+  while (addrs.length < n) {
+    for (const [, addr] of cases) addrs.push(addr);
+  }
+  return addrs.slice(0, n);
+};
+
+group("batch_v4", () => {
+  for (const n of BATCH_SIZES) {
+    const addrs = repeat(V4, n);
+    bench(`n=${n}`, () => country_code(addrs));
+  }
+});
+
+group("batch_v6", () => {
+  for (const n of BATCH_SIZES) {
+    const addrs = repeat(V6, n);
+    bench(`n=${n}`, () => country_code(addrs));
   }
 });
 

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -9,12 +9,10 @@
   "exports": {
     ".": {
       "types": "./pkg-nodejs/iptocc_wasm.d.ts",
-      "node": {
-        "require": "./pkg-nodejs/iptocc_wasm.js",
-        "import": "./pkg-bundler/iptocc_wasm.js"
-      },
       "deno": "./pkg-deno/iptocc_wasm.js",
       "browser": "./pkg-web/iptocc_wasm.js",
+      "module": "./pkg-bundler/iptocc_wasm.js",
+      "node": "./pkg-nodejs/iptocc_wasm.js",
       "default": "./pkg-bundler/iptocc_wasm.js"
     },
     "./nodejs": "./pkg-nodejs/iptocc_wasm.js",

--- a/bindings/wasm/tests/api.test.js
+++ b/bindings/wasm/tests/api.test.js
@@ -41,3 +41,13 @@ for (const { name, inputs, expected } of batchCases) {
     assert.deepStrictEqual(country_code(inputs), expected);
   });
 }
+
+test("package entry point via require", () => {
+  const pkg = require("@roniemartinez/iptocc");
+  assert.strictEqual(pkg.country_code("8.8.8.8"), "US");
+});
+
+test("package entry point via import", async () => {
+  const pkg = await import("@roniemartinez/iptocc");
+  assert.strictEqual(pkg.country_code("8.8.8.8"), "US");
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Node.js and WebAssembly usage examples with separate ESM and CommonJS code blocks.
  - Removed module-system labeling comments from examples.
  - Refreshed performance figures and benchmark tables, including batch-operation measurements and updated reference environment details.

- **Compatibility**
  - Updated package exports with direct module and Node.js targets.

- **Tests**
  - Added coverage confirming the WebAssembly package works through both CommonJS and dynamic ESM imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->